### PR TITLE
Uniformize array indices and sizes to integer

### DIFF
--- a/R/debug_pipe.R
+++ b/R/debug_pipe.R
@@ -28,8 +28,8 @@ debug_fseq <- function(fseq, ...)
   is_valid_index <- function(i) i %in% 1:length(functions(fseq))
 
   indices <- list(...)
-    if (!any(vapply(indices, is.numeric, logical(1))) ||
-        !any(vapply(indices, is_valid_index, logical(1))))
+    if (!any(vapply(indices, is.numeric, logical(1L))) ||
+        !any(vapply(indices, is_valid_index, logical(1L))))
       stop("Index or indices invalid.", call. = FALSE)
 
   invisible(lapply(indices, function(i) debug(functions(fseq)[[i]])))

--- a/R/first_type.R
+++ b/R/first_type.R
@@ -4,7 +4,7 @@
 # @return logical - TRUE if expr is of "first-argument" type, FALSE otherwise.
 is_first <- function(expr)
 {
-  !any(vapply(expr[-1], identical, logical(1), quote(.)))
+  !any(vapply(expr[-1L], identical, logical(1L), quote(.)))
 }
 
 # Prepare a magrittr rhs of "first-argument" type.

--- a/R/is_something.R
+++ b/R/is_something.R
@@ -16,7 +16,7 @@ is_pipe <- function(pipe)
 # @retun logical - TRUE if expression is parenthesized, FALSE otherwise.
 is_parenthesized <- function(expr)
 {
-  is.call(expr) && identical(expr[[1]], quote(`(`))
+  is.call(expr) && identical(expr[[1L]], quote(`(`))
 }
 
 # Check whether a pipe is a tee.
@@ -40,7 +40,7 @@ is_dollar <- function(pipe)
 # Check whether a pipe is the compound assignment pipe operator
 #
 # @param pipe A (quoted) pipe
-# @return logical - TRUE if pipe is the compound assignment pipe, 
+# @return logical - TRUE if pipe is the compound assignment pipe,
 #   otherwise FALSE.
 is_compound_pipe <- function(pipe)
 {
@@ -53,8 +53,8 @@ is_compound_pipe <- function(pipe)
 # @return logical - TRUE if expr is enclosed in `{`, FALSE otherwise.
 is_funexpr <- function(expr)
 {
-  is.call(expr) && identical(expr[[1]], quote(`{`))
-}	
+  is.call(expr) && identical(expr[[1L]], quote(`{`))
+}
 
 # Check whether expression has double or triple colons
 #
@@ -73,4 +73,4 @@ is_colexpr <- function(expr)
 is_placeholder <- function(symbol)
 {
   identical(symbol, quote(.))
-}	
+}


### PR DESCRIPTION
- Most array indices were already integer
- Using integer array sizes saves one cast in [`asVecSize`](https://github.com/wch/r-source/blob/cf829c12299b8571cd67e9d8aae88ac31450c73c/src/main/builtin.c#L36) (called by [`do_makevector`](https://github.com/wch/r-source/blob/cf829c12299b8571cd67e9d8aae88ac31450c73c/src/main/builtin.c#L741)). Depending on the processor/compiler, the performance gain might be minor here, but it shouldn’t hurt.
- As a side note, sequences don’t need explicit integers because they are read as double by [`do_colon`](https://github.com/wch/r-source/blob/86b832f58109a3c71f321e8eb080323e8aebd389/src/main/seq.c#L170) and fed as double arguments to [`seq_colon`](https://github.com/wch/r-source/blob/86b832f58109a3c71f321e8eb080323e8aebd389/src/main/seq.c#L96)