### PR TITLE
documentation 'seealso' link correction

### DIFF
--- a/man/exposition.Rd
+++ b/man/exposition.Rd
@@ -29,6 +29,6 @@ data.frame(z = rnorm(100)) \%$\%
   ts.plot(z)
 }
 \seealso{
-\code{\link{\%>\%}}, \code{\link{\%<>\%}}, \code{\link{\%$\%}}
+\code{\link{\%>\%}}, \code{\link{\%<>\%}}, \code{\link{\%T>\%}}
 }
 


### PR DESCRIPTION
'seealso' previously linked back to exposition instead of tee operator

fixed the link under `%$%`
Changed from `%$%` to `%T>%`